### PR TITLE
#47 Fixed it

### DIFF
--- a/WebAnchor.Tests/ProofOfConcepts/StackOverflowQuestion28413765/Tests.cs
+++ b/WebAnchor.Tests/ProofOfConcepts/StackOverflowQuestion28413765/Tests.cs
@@ -18,7 +18,7 @@ namespace WebAnchor.Tests.ProofOfConcepts.StackOverflowQuestion28413765
                 m =>
                     {
                         Assert.AreEqual(HttpMethod.Get, m.Method);
-                        Assert.AreEqual("/track/?content-type[]=Type1&content-type[]=Type3", m.RequestUri.ToString());
+                        Assert.AreEqual("/track?content-type[]=Type1&content-type[]=Type3", m.RequestUri.ToString());
                     });
         }
     }

--- a/WebAnchor.Tests/RequestFactory/Url/IApi.cs
+++ b/WebAnchor.Tests/RequestFactory/Url/IApi.cs
@@ -1,0 +1,18 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using WebAnchor.RequestFactory;
+using WebAnchor.RequestFactory.HttpAttributes;
+
+namespace WebAnchor.Tests.RequestFactory.Url
+{
+    [BaseLocation("base")]
+    public interface IApi
+    {
+        [Get("/path1")]
+        Task<HttpResponseMessage> Get();
+        
+        [Get("path2")]
+        Task<HttpResponseMessage> Get2();
+    }
+}

--- a/WebAnchor.Tests/RequestFactory/Url/UrlCreationTests.cs
+++ b/WebAnchor.Tests/RequestFactory/Url/UrlCreationTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Net.Http;
+
+using NUnit.Framework;
+
+using WebAnchor.Tests.RequestFactory.Transformation.Custom;
+using WebAnchor.Tests.TestUtils;
+
+namespace WebAnchor.Tests.RequestFactory.Url
+{
+    [TestFixture]
+    public class UrlCreationTests : WebAnchorTest
+    {
+        [Test]
+        public void ConcatBaseLocationWithVerb()
+        {
+            TestTheRequest<IApi>(
+                api => api.Get(),
+                m =>
+                    {
+                        Assert.AreEqual(HttpMethod.Get, m.Method);
+                        Assert.AreEqual("base/path1", m.RequestUri.ToString());
+                    });
+        }
+
+        [Test]
+        public void ConcatBaseLocationWithVerb_SlashIsAppendedIfMissing()
+        {
+            TestTheRequest<IApi>(
+                api => api.Get2(),
+                m =>
+                {
+                    Assert.AreEqual(HttpMethod.Get, m.Method);
+                    Assert.AreEqual("base/path2", m.RequestUri.ToString());
+                });
+        }
+
+        [Test]
+        public void ConcatBaseLocationWithVerb_SlashIsAppendedIfMissingUnlessDisabled()
+        {
+            TestTheRequest<IApi>(
+                api => api.Get2(),
+                m =>
+                {
+                    Assert.AreEqual(HttpMethod.Get, m.Method);
+                    Assert.AreEqual("basepath2", m.RequestUri.ToString());
+                },
+                settings: new ApiSettings
+                {
+                    InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl = false
+                });
+        }
+    }
+}

--- a/WebAnchor.Tests/TestUtils/InvocationTester.cs
+++ b/WebAnchor.Tests/TestUtils/InvocationTester.cs
@@ -4,8 +4,6 @@ using System.Net.Http;
 
 using Castle.DynamicProxy;
 
-using Newtonsoft.Json;
-
 using WebAnchor.RequestFactory;
 using WebAnchor.RequestFactory.Transformation;
 
@@ -19,8 +17,11 @@ namespace WebAnchor.Tests.TestUtils
 
         private readonly Action<IEnumerable<Parameter>, ParameterTransformContext> _pipelineAction;
 
-        public InvocationTester(Action<HttpRequestMessage> assert = null, Action<HttpRequestFactory> configure = null, Action<IEnumerable<Parameter>, ParameterTransformContext> pipelineAction = null)
+        private readonly ApiSettings _settings;
+
+        public InvocationTester(Action<HttpRequestMessage> assert = null, Action<HttpRequestFactory> configure = null, Action<IEnumerable<Parameter>, ParameterTransformContext> pipelineAction = null, ApiSettings settings = null)
         {
+            _settings = settings ?? new ApiSettings();
             _assert = assert ?? (a => { });
             _configure = configure ?? (a => { });
             _pipelineAction = pipelineAction ?? ((a, b) => { });
@@ -28,9 +29,8 @@ namespace WebAnchor.Tests.TestUtils
 
         public void Intercept(IInvocation invocation)
         {
-            var settings = new ApiSettings();
-            settings.ParameterListTransformers.Add(new TestTransformer(_pipelineAction));
-            var factory = (HttpRequestFactory)settings.GetRequestFactory();
+            _settings.ParameterListTransformers.Add(new TestTransformer(_pipelineAction));
+            var factory = (HttpRequestFactory)_settings.GetRequestFactory();
             _configure(factory);
             var httpRequest = factory.Create(invocation);
             _assert(httpRequest);

--- a/WebAnchor.Tests/TestUtils/WebAnchorTest.cs
+++ b/WebAnchor.Tests/TestUtils/WebAnchorTest.cs
@@ -11,9 +11,9 @@ namespace WebAnchor.Tests.TestUtils
 {
     public class WebAnchorTest
     {
-        protected void TestTheRequest<T>(Action<T> action, Action<HttpRequestMessage> assertHttpRequestMessage, Action<HttpRequestFactory> configure = null, Action<IEnumerable<Parameter>, ParameterTransformContext> assertParametersAndContext = null) where T : class
+        protected void TestTheRequest<T>(Action<T> action, Action<HttpRequestMessage> assertHttpRequestMessage, Action<HttpRequestFactory> configure = null, Action<IEnumerable<Parameter>, ParameterTransformContext> assertParametersAndContext = null, ApiSettings settings = null) where T : class
         {
-            var api = new ProxyGenerator().CreateInterfaceProxyWithoutTarget<T>(new InvocationTester(assertHttpRequestMessage, configure, assertParametersAndContext));
+            var api = new ProxyGenerator().CreateInterfaceProxyWithoutTarget<T>(new InvocationTester(assertHttpRequestMessage, configure, assertParametersAndContext, settings));
             action(api);
         }
     }

--- a/WebAnchor.Tests/WebAnchor.Tests.csproj
+++ b/WebAnchor.Tests/WebAnchor.Tests.csproj
@@ -66,6 +66,8 @@
     <Compile Include="RequestFactory\Transformation\Transformers\Default\AsDictionaryAttributeTest\AClassAsDictionary.cs" />
     <Compile Include="RequestFactory\Transformation\Transformers\Default\AsDictionaryAttributeTest\ApiInterface.cs" />
     <Compile Include="RequestFactory\Transformation\Transformers\Default\AsDictionaryAttributeTest\Tests.cs" />
+    <Compile Include="RequestFactory\Url\IApi.cs" />
+    <Compile Include="RequestFactory\Url\UrlCreationTests.cs" />
     <Compile Include="TestUtils\TestTransformer.cs" />
     <Compile Include="Validation\ConcreteClass.cs" />
     <Compile Include="ACollectionOfRandomTests\Tests.cs" />

--- a/WebAnchor/ApiSettings.cs
+++ b/WebAnchor/ApiSettings.cs
@@ -15,15 +15,20 @@ namespace WebAnchor
             ParameterListTransformers = new DefaultParameterListTransformers();
             ResponseHandlers = new DefaultResponseHandlers();
             ContentSerializer = new ContentSerializer(new JsonSerializer());
+            InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl = true;
         }
 
         public virtual List<IParameterListTransformer> ParameterListTransformers { get; set; }
         public virtual List<IResponseHandler> ResponseHandlers { get; set; }
         public virtual IContentSerializer ContentSerializer { get; set; }
 
+        public virtual bool InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl { get; set; }
+
         public IHttpRequestFactory GetRequestFactory()
         {
-            return new HttpRequestFactory(ContentSerializer, ParameterListTransformers);
+            var requestFactory = new HttpRequestFactory(ContentSerializer, ParameterListTransformers);
+            requestFactory.InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl = InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl;
+            return requestFactory;
         }
 
         public IHttpResponseParser GetResponseParser()

--- a/WebAnchor/RequestFactory/HttpRequestFactory.cs
+++ b/WebAnchor/RequestFactory/HttpRequestFactory.cs
@@ -17,12 +17,14 @@ namespace WebAnchor.RequestFactory
         {
             ContentSerializer = contentSerializer;
             ParameterListTransformers = transformers ?? new List<IParameterListTransformer>();
+            InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl = true;
         }
 
         public IContentSerializer ContentSerializer { get; set; }
         public IList<IParameterListTransformer> ParameterListTransformers { get; set; }
         public Parameters ResolvedParameters { get; set; }
-        
+        public bool InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl { get; set; }
+
         public virtual void ValidateApi(Type type)
         {
             foreach (var parameterListTransformer in ParameterListTransformers)
@@ -84,7 +86,7 @@ namespace WebAnchor.RequestFactory
             var substitutedUrl = methodAttribute.URL.Replace(
                     ResolvedParameters.RouteParameters.ToDictionary(x => CreateRouteSegmentId(x.Name), CreateRouteSegmentValue));
 
-            var resolvedUrl = (baseAttribute != null ? baseAttribute.BaseUrl : string.Empty) + substitutedUrl;
+            var resolvedUrl = ((baseAttribute != null ? baseAttribute.BaseUrl + (InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl ? "/" : string.Empty) : string.Empty) + substitutedUrl).Replace("//", "/").Replace("/?", "?").TrimEnd('/');
             resolvedUrl = AppendUrlParams(resolvedUrl, ResolvedParameters.QueryParameters);
             return resolvedUrl;
         }


### PR DESCRIPTION
Default behaviour is now inserting "/" if missing.
Also added cleanup of url by replacing any double slashes "//" with "/"
and any "/?" with only "?" Also any trailing slashes have been removed.
To override this behaviour, set
InsertMissingSlashBetweenBaseLocationAndVerbAttributeUrl to false in
ApiSettings