### PR TITLE
Enables custom attributes that can include content

### DIFF
--- a/WebAnchor.Tests/RequestFactory/Url/CustomHttpAttributeTests.cs
+++ b/WebAnchor.Tests/RequestFactory/Url/CustomHttpAttributeTests.cs
@@ -1,5 +1,4 @@
-﻿
-using WebAnchor.TestUtils;
+﻿using WebAnchor.TestUtils;
 using Xunit;
 
 namespace WebAnchor.Tests.RequestFactory.Url

--- a/WebAnchor.Tests/RequestFactory/Url/CustomHttpAttributeTests.cs
+++ b/WebAnchor.Tests/RequestFactory/Url/CustomHttpAttributeTests.cs
@@ -1,0 +1,29 @@
+﻿
+using WebAnchor.TestUtils;
+using Xunit;
+
+namespace WebAnchor.Tests.RequestFactory.Url
+{
+    public class CustomHttpAttributeTests : WebAnchorTest
+    {
+        [Fact]
+        public void CustomVerb()
+        {
+            TestTheRequest<IApi>(api => api.TestVerb(), m => 
+            {
+                Assert.Equal("TEST", m.Method.Method);
+                Assert.Null(m.Content);
+            });
+        }
+
+        [Fact]
+        public void CustomVerb_WithContent()
+        {
+            TestTheRequest<IApi>(api => api.TestVerbWithContent(new TestContent { Message = "content" }), m =>
+            {
+                Assert.Equal("TEST", m.Method.Method);
+                Assert.NotNull(m.Content);
+            });
+        }
+    }
+}

--- a/WebAnchor.Tests/RequestFactory/Url/IApi.cs
+++ b/WebAnchor.Tests/RequestFactory/Url/IApi.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
+using WebAnchor.Attributes.Content;
 using WebAnchor.Attributes.URL;
 
 namespace WebAnchor.Tests.RequestFactory.Url
@@ -15,5 +16,28 @@ namespace WebAnchor.Tests.RequestFactory.Url
 
         [Get("{path}")]
         Task<HttpResponseMessage> Get3(string path);
+
+        [TestVerb()]
+        Task<HttpResponseMessage> TestVerb();
+
+        [TestVerb(includeContent: true)]
+        Task<HttpResponseMessage> TestVerbWithContent([Content] TestContent content);
+    }
+
+    public class TestContent
+    {
+        public string Message { get; set; }
+    }
+
+    public class TestVerbAttribute : HttpAttribute
+    {
+        private readonly bool _includeContent;
+
+        public TestVerbAttribute(bool includeContent = false) : base(new HttpMethod("TEST"), string.Empty)
+        {
+            _includeContent = includeContent;
+        }
+
+        public override bool IncludeContentInRequest => _includeContent;
     }
 }

--- a/WebAnchor/Attributes/URL/HttpAttribute.cs
+++ b/WebAnchor/Attributes/URL/HttpAttribute.cs
@@ -14,5 +14,6 @@ namespace WebAnchor.Attributes.URL
 
         public string URL { get; set; }
         public HttpMethod Method { get; set; }
+        public virtual bool IncludeContentInRequest => false;
     }
 }

--- a/WebAnchor/Attributes/URL/PostAttribute.cs
+++ b/WebAnchor/Attributes/URL/PostAttribute.cs
@@ -11,5 +11,7 @@ namespace WebAnchor.Attributes.URL
         {
             URL = url;
         }
+
+        public override bool IncludeContentInRequest => true;
     }
 }

--- a/WebAnchor/Attributes/URL/PutAttribute.cs
+++ b/WebAnchor/Attributes/URL/PutAttribute.cs
@@ -11,5 +11,7 @@ namespace WebAnchor.Attributes.URL
         {
             URL = url;
         }
+
+        public override bool IncludeContentInRequest => true;
     }
 }

--- a/WebAnchor/RequestFactory/HttpRequestFactory.cs
+++ b/WebAnchor/RequestFactory/HttpRequestFactory.cs
@@ -51,11 +51,12 @@ namespace WebAnchor.RequestFactory
             ResolvedParameters = ResolveParameters(requestTransformContext);
 
             var resolvedUrl = ResolveUrl(requestTransformContext.UrlTemplate, requestTransformContext);
-            var resolvedMethod = ResolveHttpMethod(invocation);
+            var resolvedHttpAttribute = ResolveHttpMethodAttribute(invocation);
+            var resolvedMethod = resolvedHttpAttribute.Method;
 
             var request = new HttpRequestMessage(resolvedMethod, resolvedUrl);
 
-            if (resolvedMethod == HttpMethod.Post || resolvedMethod == HttpMethod.Put)
+            if (resolvedHttpAttribute.IncludeContentInRequest)
             {
                 request.Content = ResolveContent(requestTransformContext);
             }
@@ -118,12 +119,11 @@ namespace WebAnchor.RequestFactory
             return url + urlParams;
         }
 
-        protected virtual HttpMethod ResolveHttpMethod(IInvocation invocation)
+        protected virtual HttpAttribute ResolveHttpMethodAttribute(IInvocation invocation)
         {
             var methodInfo = invocation.Method;
             var methodAttribute = methodInfo.GetCustomAttribute<HttpAttribute>();
-            var resolvedMethod = methodAttribute.Method;
-            return resolvedMethod;
+            return methodAttribute;
         }
 
         protected virtual string CreateRouteSegmentId(string name)


### PR DESCRIPTION
Somewhat relates to #48

Solves a case where we want to use a custom verb (PATCH), but also include content. Could you take a look @mattiasnordqvist and see if you agree or would like to solve this some other way?

This PR however breaks backwards compatability of `HttpRequestFactory`. It could be easily rewritten to not break compatability (by keeping `ResolveHttpMethod` and maybe adding a `ResolveIncludeContent` or something like that), but that seems slightly clumsier.