### PR TITLE
Implemented FormUrlEncodePropertyAttribute and it's usage

### DIFF
--- a/WebAnchor.Tests/RequestFactory/Content/FormUrlEncodedContentTests.cs
+++ b/WebAnchor.Tests/RequestFactory/Content/FormUrlEncodedContentTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using WebAnchor.Attributes.Content;
+using WebAnchor.Attributes.URL;
+using WebAnchor.TestUtils;
+using Xunit;
+
+namespace WebAnchor.Tests.RequestFactory.Content
+{
+    public class FormUrlEncodedContentTests : WebAnchorTest
+    {
+        [BaseLocation("location")]
+        public interface IApi
+        {
+            [Post("resource")]
+            Task<HttpResponseMessage> Post([Content, FormUrlEncoded] Payload data);
+
+            [Post("resource")]
+            Task<HttpResponseMessage> PostCustomized([Content, FormUrlEncoded] CustomizedPayload data);
+        }
+
+        [Fact]
+        public void TestFormUrlEncodedSerialization()
+        {
+            TestTheRequest<IApi>(
+                   api => api.Post(new Payload(1, "Test")),
+                   request =>
+                   {
+                       var content = request.Content.ReadAsStringAsync().Result;
+                       Assert.Equal("Id=1&Name=Test", content);
+                   });
+        }
+
+        [Fact]
+        public void TestCustomizedFormUrlEncodedSerialization()
+        {
+            TestTheRequest<IApi>(
+                   api => api.PostCustomized(new CustomizedPayload(1, "Test")),
+                   request =>
+                   {
+                       var content = request.Content.ReadAsStringAsync().Result;
+                       Assert.Equal("Id=1&Name=Test&refresh_token=my-token", content);
+                   });
+        }
+
+        public class Payload
+        {
+            public Payload(int id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class CustomizedPayload
+        {
+            public CustomizedPayload(int id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            [FormUrlEncodedProperty("refresh_token")]
+            public string RefreshToken => "my-token";
+        }
+    }
+}

--- a/WebAnchor/Attributes/Content/FormUrlEncodedPropertyAttribute.cs
+++ b/WebAnchor/Attributes/Content/FormUrlEncodedPropertyAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace WebAnchor.Attributes.Content
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class FormUrlEncodedPropertyAttribute : Attribute
+    {
+        public FormUrlEncodedPropertyAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}

--- a/WebAnchor/RequestFactory/Serialization/FormUrlEncodedSerializer.cs
+++ b/WebAnchor/RequestFactory/Serialization/FormUrlEncodedSerializer.cs
@@ -26,8 +26,6 @@ namespace WebAnchor.RequestFactory.Serialization
                 var value = property.GetGetMethod().Invoke(content, null)?.ToString() ?? string.Empty;
                 yield return new KeyValuePair<string, string>(name, value);
             }
-
-            yield break;
         }
     }
 }


### PR DESCRIPTION
Fixes #90
Enables custom form url encoded parameters like so
```
        public class CustomizedPayload
        {
            public int Id { get; set; }
            public string Name { get; set; }

            [FormUrlEncodedProperty("refresh_token")]
            public string RefreshToken => "my-token";
        }
```
in a similar way to how it's done with json using the `[JsonProperty("refresh_token")]`